### PR TITLE
Feat spanners

### DIFF
--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -67,7 +67,7 @@ class GTData:
 class _Sequence(Sequence[T]):
     _d: list[T]
 
-    def __init__(self, data: Any):
+    def __init__(self, data: list[T]):
         self._d = data
 
     @overload
@@ -322,11 +322,9 @@ import pandas as pd
 
 @dataclass
 class SpannerInfo:
-    # TODO: I made spanner_level mandatory, so it could always be types int.
-    # does gt ever need set this to None?
-    spanner_level: int
-    spanner_label: list[str] = field(default_factory=lambda: [])
-    spanner_id: list[str] = field(default_factory=lambda: [])
+    spanner_id: str
+    spanner_level: int | None = None
+    spanner_label: str | None = None
     vars: list[str] = field(default_factory=lambda: [])
     gather: Optional[bool] = None
     built: Optional[str] = None

--- a/great_tables/_gt_data.py
+++ b/great_tables/_gt_data.py
@@ -158,34 +158,35 @@ class ColumnAlignment(Enum):
     Justify = auto()
 
 
+class ColInfoTypeEnum(Enum):
+    default = auto()
+    stub = auto()
+    row_group = auto()
+    hidden = auto()
+
+
+@dataclass
 class ColInfo:
     # TODO: Make var readonly
     var: str
-    visible: bool
-    column_label: str
-    column_align: Optional[ColumnAlignment]
-    column_width: Optional[str]
+    type: ColInfoTypeEnum = ColInfoTypeEnum.default
+    column_label: Optional[str] = None
+    column_align: Optional[ColumnAlignment] = None
+    column_width: Optional[str] = None
 
     # The components of the boxhead are:
     # `var` (obtained from column names)
     # `column_label` (obtained from column names)
-    # `visible` = True
     # `column_align` = None
     # `column_width` = None
 
-    def __init__(
-        self,
-        var: str,
-        visible: bool = True,
-        column_label: Optional[str] = None,
-        column_align: Optional[ColumnAlignment] = None,
-        column_width: Optional[str] = None,
-    ):
-        self.var = var
-        self.visible = visible
-        self.column_label = column_label or var
-        self.column_align = column_align
-        self.column_width = column_width
+    def __post_init__(self):
+        if self.column_label is None:
+            self.column_label = self.var
+
+    @property
+    def visible(self) -> bool:
+        return self.type != ColInfoTypeEnum.hidden
 
 
 class Boxhead(_Sequence[ColInfo]):

--- a/great_tables/_locations.py
+++ b/great_tables/_locations.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+from functools import singledispatch
+from typing import TYPE_CHECKING, Literal, get_origin, get_type_hints
+
+# note that types like Spanners are only used in annotations for concretes of the
+# resolve generic, but we need to import at runtime, due to singledispatch looking
+# up annotations
+from ._gt_data import GTData, Spanners
+
+
+# Locations ============================================================================
+# TODO: these are called cells_* in gt. I prefixed them with Loc just to keep things
+# straight while going through helpers.R, but no strong opinion on naming!
+
+
+@dataclass
+class Loc:
+    """A location."""
+
+
+@dataclass
+class LocTitle(Loc):
+    """A location for targeting the table title and subtitle."""
+
+    groups: Literal["title", "subtitle"]
+
+
+@dataclass
+class LocStubhead(Loc):
+    groups: Literal["stubhead"] = "stubhead"
+
+
+@dataclass
+class LocColumnSpanners(Loc):
+    """A location for column spanners."""
+
+    # TODO: these can also be tidy selectors
+    ids: list[str]
+
+
+@dataclass
+class LocColumnLabels(Loc):
+    # TODO: these can be tidyselectors
+    columns: list[str]
+
+
+@dataclass
+class LocRowGroups(Loc):
+    # TODO: these can be tidyselectors
+    groups: list[str]
+
+
+@dataclass
+class LocStub(Loc):
+    # TODO: these can be tidyselectors
+    # TODO: can this take integers?
+    rows: list[str]
+
+
+@dataclass
+class LocBody(Loc):
+    # TODO: these can be tidyselectors
+    columns: list[str]
+    rows: list[str]
+
+
+@dataclass
+class LocSummary(Loc):
+    # TODO: these can be tidyselectors
+    groups: list[str]
+    columns: list[str]
+    rows: list[str]
+
+
+@dataclass
+class LocGrandSummary(Loc):
+    # TODO: these can be tidyselectors
+    columns: list[str]
+    rows: list[str]
+
+
+@dataclass
+class LocStubSummary(Loc):
+    # TODO: these can be tidyselectors
+    groups: list[str]
+    rows: list[str]
+
+
+@dataclass
+class LocStubGrandSummary(Loc):
+    rows: list[str]
+
+
+@dataclass
+class LocFootnotes(Loc):
+    groups: Literal["footnotes"] = "footnotes"
+
+
+@dataclass
+class LocSourceNotes(Loc):
+    # This dataclass in R has a `groups` field, which is a literal value.
+    # In python, we can use an isinstance check to determine we're seeing an
+    # instance of this class
+    groups: Literal["source_notes"] = "source_notes"
+
+
+# Utils ================================================================================
+
+
+def resolve_vector_i(expr: list[str], candidates: list[str], item_label: str) -> list[int]:
+    """Return list of indices for candidates, selected by expr."""
+
+    mask = resolve_vector_l(expr, candidates, item_label)
+    return [ii for ii, val in enumerate(mask) if val]
+
+
+def resolve_vector_l(expr: list[str], candidates: list[str], item_label: str) -> list[bool]:
+    """Return list of logical index for candidates, selected by expr."""
+
+    if not (isinstance(expr, list) and all(isinstance(x, str) for x in expr)):
+        raise NotImplementedError("Selecting entries currently requires a list of strings.")
+
+    set_expr = set(expr)
+    if set_expr - set(candidates):
+        missing = set_expr - set(candidates)
+        raise ValueError(f"Cannot find these entries: {missing}")
+
+    return [candidate in set_expr for candidate in candidates]
+
+
+# Resolve generic ======================================================================
+
+
+@singledispatch
+def resolve(loc: Loc, *args, **kwargs) -> Loc:
+    """Return a copy of location with lookups resolved (e.g. tidyselect on columns)."""
+    raise NotImplementedError(f"Unsupported location type: {type(loc)}")
+
+
+@resolve.register
+def _(loc: LocColumnSpanners, spanners: Spanners) -> LocColumnSpanners:
+    # unique labels (with order preserved)
+    spanner_ids = [span.spanner_id for span in spanners]
+
+    resolved_spanners_idx = resolve_vector_i(loc.ids, spanner_ids, item_label="spanner")
+    resolved_spanners = [spanner_ids[idx] for idx in resolved_spanners_idx]
+
+    # Create a list object
+    return LocColumnSpanners(ids=resolved_spanners)

--- a/great_tables/_locations.py
+++ b/great_tables/_locations.py
@@ -130,6 +130,32 @@ def resolve_vector_l(expr: list[str], candidates: list[str], item_label: str) ->
     return [candidate in set_expr for candidate in candidates]
 
 
+def resolve_cols_c(
+    expr: list[str],
+    data: GTData,
+    strict: bool = True,
+    excl_stub: bool = True,
+    excl_group: bool = True,
+    null_means: Literal["everything", "nothing"] = "everything",
+) -> list[str]:
+    selected = resolve_cols_i(expr, data, strict, excl_stub, excl_group, null_means)
+    return [name_pos[0] for name_pos in selected]
+
+
+def resolve_cols_i(
+    expr: list[str],
+    data: GTData,
+    strict: bool = True,
+    excl_stub: bool = True,
+    excl_group: bool = True,
+    null_means: Literal["everything", "nothing"] = "everything",
+) -> list[tuple[str, int]]:
+    """Return a tuple of (column name, position) pairs, selected by expr."""
+
+    # TODO: special handling of "stub()"
+    raise NotImplementedError()
+
+
 # Resolve generic ======================================================================
 
 

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -1,5 +1,77 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, NewType, Union, List, Dict
 
-class SpannersAPI:
-    pass
+from ._gt_data import Spanners
+
+if TYPE_CHECKING:
+    from ._gt_data import Boxhead
+
+
+SpannerMatrix = List[Dict[str, Union[str, None]]]
+
+
+def spanners_print_matrix(
+    spanners: Spanners,
+    boxhead: Boxhead,
+    include_hidden: bool = False,
+    ids: bool = False,
+    omit_columns_row: bool = False,
+) -> tuple[SpannerMatrix, list[str]]:
+    if not include_hidden:
+        # TODO: no "type" field on boxhead, is this use of visible right?
+        vars = [row.var for row in boxhead if row.visible]
+    else:
+        vars = [row.var for row in boxhead]
+
+    if not spanners:
+        return empty_spanner_matrix(vars=vars, omit_columns_row=omit_columns_row)
+
+    # Modify `spanners_tbl` such that:
+    # (1) only visible vars are included in the `vars` column
+    # (2) entries with no vars (after step 1) are removed, and
+    # (3) `spanner_level` values have all gaps removed, being compressed
+    #     down to start at 1 (e.g., 7, 5, 3, 1 -> 4, 3, 2, 1)
+    _vars = [set(span.vars) & set(vars) for span in spanners]
+    _lvls = sorted({span.spanner_level for span in spanners})
+
+    non_empty_spans = [span for crnt_vars, span in zip(_vars, spanners) if len(crnt_vars)]
+    new_levels = [_lvls.index(span.spanner_level) for span in non_empty_spans]
+
+    crnt_spans = Spanners(non_empty_spans).relevel(new_levels)
+
+    if not crnt_spans:
+        return empty_spanner_matrix(vars=vars, omit_columns_row=omit_columns_row)
+
+    spanner_height = len(_lvls)
+    # TODO: span.built can be None. When does it get set?
+    spanner_reprs = [span.spanner_id if ids else span.built for span in crnt_spans]
+
+    # Create a matrix with dimension spanner_height x vars (e.g. presented columns)
+    label_matrix: SpannerMatrix = [
+        {var_name: None for var_name in vars} for _ in range(spanner_height)
+    ]
+    print(spanner_reprs)
+
+    for span_ii, span in enumerate(crnt_spans):
+        for var in span.vars:
+            print(var)
+            label_matrix[span.spanner_level][var] = spanner_reprs[span_ii]
+
+    # reverse order , so if you were to print it out, level 0 would appear on the bottom
+    label_matrix.reverse()
+
+    # add column names to matrix
+    if not omit_columns_row:
+        label_matrix.append({var: var for var in vars})
+
+    return label_matrix, vars
+
+
+def empty_spanner_matrix(
+    vars: list[str], omit_columns_row: bool
+) -> tuple[SpannerMatrix, list[str]]:
+    if omit_columns_row:
+        return [], vars
+
+    return [{var: var for var in vars}], vars

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -1,14 +1,29 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, NewType, Union, List, Dict
+from typing import TYPE_CHECKING, NewType, Union, List, Dict, Optional
 
 from ._gt_data import Spanners
 
 if TYPE_CHECKING:
-    from ._gt_data import Boxhead
+    from ._gt_data import GTData, Boxhead
 
 
 SpannerMatrix = List[Dict[str, Union[str, None]]]
+
+
+def tab_spanner(
+    data: GTData,
+    label: str,
+    columns: Optional[list[str]] = None,
+    spanners: Optional[list[str]] = None,
+    level: Optional[int] = None,
+    id: Optional[str] = None,
+    gather: bool = True,
+    replace: bool = False,
+):
+    crnt_spanner_ids = [span.spanner_id for span in data._spanners]
+    column_names = resolve_cols_c(columns)
+    raise NotImplementedError()
 
 
 def spanners_print_matrix(

--- a/great_tables/_spanners.py
+++ b/great_tables/_spanners.py
@@ -61,7 +61,7 @@ def tab_spanner(
         level = data._spanners.next_level(column_names)
 
     # get spanner units and labels ----
-    # TODO: walk through this with Rich
+    # TODO: grep units from {{.*}}, may need to switch delimiters
     spanner_units = None
     spanner_pattern = None
 
@@ -80,7 +80,7 @@ def tab_spanner(
     new_data = data.replace(_spanners=spanners)
 
     if gather and not len(spanner_ids) and level == 0:
-        return cols_move(new_data, columns=column_names, after=column_names[1])
+        return cols_move(new_data, columns=column_names, after=column_names[0])
 
     return new_data
 
@@ -154,3 +154,23 @@ def empty_spanner_matrix(
         return [], vars
 
     return [{var: var for var in vars}], vars
+
+
+def seq_groups(seq: list[str]):
+    # TODO: 0-length sequence
+    if len(seq) == 0:
+        raise StopIteration
+    elif len(seq) == 1:
+        yield seq[0], 1
+    else:
+        crnt_ttl = 1
+        for crnt_el, next_el in zip(seq[:-1], seq[1:]):
+            if crnt_el == next_el:
+                crnt_ttl += 1
+            else:
+                yield crnt_el, crnt_ttl
+                crnt_ttl = 1
+
+        # final step has same elements, so we need to yield one last time
+        if crnt_el == next_el:
+            yield crnt_el, crnt_ttl

--- a/great_tables/_styles.py
+++ b/great_tables/_styles.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from ._gt_data import GTData
+from ._locations import Loc
 
 from dataclasses import dataclass
 from typing import Optional, Literal
@@ -59,102 +60,6 @@ class CellStyleBorders(CellStyle):
     style: str
     # TODO: this can include objects like px(1)
     weight: str
-
-
-# Locations ============================================================================
-# TODO: these are called cells_* in gt. I prefixed them with Loc just to keep things
-# straight while going through helpers.R, but no strong opinion on naming!
-
-
-@dataclass
-class Loc:
-    """A location."""
-
-
-@dataclass
-class LocTitle(Loc):
-    """A location for targeting the table title and subtitle."""
-
-    groups: Literal["title", "subtitle"]
-
-
-@dataclass
-class LocStubhead(Loc):
-    groups: Literal["stubhead"] = "stubhead"
-
-
-@dataclass
-class LocColumnSpanners(Loc):
-    """A location for column spanners."""
-
-    # TODO: these can also be tidy selectors
-    ids: list[str]
-
-
-@dataclass
-class LocColumnLabels(Loc):
-    # TODO: these can be tidyselectors
-    columns: list[str]
-
-
-@dataclass
-class LocRowGroups(Loc):
-    # TODO: these can be tidyselectors
-    groups: list[str]
-
-
-@dataclass
-class LocStub(Loc):
-    # TODO: these can be tidyselectors
-    # TODO: can this take integers?
-    rows: list[str]
-
-
-@dataclass
-class LocBody(Loc):
-    # TODO: these can be tidyselectors
-    columns: list[str]
-    rows: list[str]
-
-
-@dataclass
-class LocSummary(Loc):
-    # TODO: these can be tidyselectors
-    groups: list[str]
-    columns: list[str]
-    rows: list[str]
-
-
-@dataclass
-class LocGrandSummary(Loc):
-    # TODO: these can be tidyselectors
-    columns: list[str]
-    rows: list[str]
-
-
-@dataclass
-class LocStubSummary(Loc):
-    # TODO: these can be tidyselectors
-    groups: list[str]
-    rows: list[str]
-
-
-@dataclass
-class LocStubGrandSummary(Loc):
-    rows: list[str]
-
-
-@dataclass
-class LocFootnotes(Loc):
-    groups: Literal["footnotes"] = "footnotes"
-
-
-@dataclass
-class LocSourceNotes(Loc):
-    # This dataclass in R has a `groups` field, which is a literal value.
-    # In python, we can use an isinstance check to determine we're seeing an
-    # instance of this class
-    groups: Literal["source_notes"] = "source_notes"
 
 
 def tab_style(data: GTData, style: list[CellStyle] | CellStyle, locations: Loc):

--- a/great_tables/_styles.py
+++ b/great_tables/_styles.py
@@ -1,5 +1,171 @@
 from __future__ import annotations
 
+from ._gt_data import GTData
 
-class StylesAPI:
-    pass
+from dataclasses import dataclass
+from typing import Optional, Literal
+
+
+# Cell Styles ==========================================================================
+# TODO: stubbed out the styles in helpers.R as dataclasses while I was reading it,
+# but have no worked on any runtime validation, etc..
+
+
+@dataclass
+class CellStyle:
+    """A style specification."""
+
+
+@dataclass
+class CellText:
+    """A style specification for text."""
+
+    color: str
+    font: str
+    size: str
+    align: Literal["center", "left", "right", "justify"]
+    # TODO: this can also be a gt_column object?
+    v_align: Literal["middle", "top", "bottom"]
+    style: Literal["normal", "italic", "oblique"]
+    weight: Literal["normal", "bold", "bolder", "lighter"]
+    stretch: Literal[
+        "normal",
+        "condensed",
+        "ultra-condensed",
+        "extra-condensed",
+        "semi-condensed",
+        "semi-expanded",
+        "expanded",
+        "extra-expanded",
+        "ultra-expanded",
+    ]
+    decorate: Literal["overline", "line-through", "underline", "underline overline"]
+    transform: Literal["uppercase", "lowercase", "capitalize"]
+    whitespace: Literal["normal", "nowrap", "pre", "pre-wrap", "pre-line", "break-spaces"]
+
+
+@dataclass
+class CellStyleFill(CellStyle):
+    """A style specification for fill."""
+
+    fill: str
+    alpha: Optional[float] = None
+
+
+@dataclass
+class CellStyleBorders(CellStyle):
+    sides: Literal["all", "top", "bottom", "left", "right"]
+    color: str
+    style: str
+    # TODO: this can include objects like px(1)
+    weight: str
+
+
+# Locations ============================================================================
+# TODO: these are called cells_* in gt. I prefixed them with Loc just to keep things
+# straight while going through helpers.R, but no strong opinion on naming!
+
+
+@dataclass
+class Loc:
+    """A location."""
+
+
+@dataclass
+class LocTitle(Loc):
+    """A location for targeting the table title and subtitle."""
+
+    groups: Literal["title", "subtitle"]
+
+
+@dataclass
+class LocStubhead(Loc):
+    groups: Literal["stubhead"] = "stubhead"
+
+
+@dataclass
+class LocColumnSpanners(Loc):
+    """A location for column spanners."""
+
+    # TODO: these can also be tidy selectors
+    ids: list[str]
+
+
+@dataclass
+class LocColumnLabels(Loc):
+    # TODO: these can be tidyselectors
+    columns: list[str]
+
+
+@dataclass
+class LocRowGroups(Loc):
+    # TODO: these can be tidyselectors
+    groups: list[str]
+
+
+@dataclass
+class LocStub(Loc):
+    # TODO: these can be tidyselectors
+    # TODO: can this take integers?
+    rows: list[str]
+
+
+@dataclass
+class LocBody(Loc):
+    # TODO: these can be tidyselectors
+    columns: list[str]
+    rows: list[str]
+
+
+@dataclass
+class LocSummary(Loc):
+    # TODO: these can be tidyselectors
+    groups: list[str]
+    columns: list[str]
+    rows: list[str]
+
+
+@dataclass
+class LocGrandSummary(Loc):
+    # TODO: these can be tidyselectors
+    columns: list[str]
+    rows: list[str]
+
+
+@dataclass
+class LocStubSummary(Loc):
+    # TODO: these can be tidyselectors
+    groups: list[str]
+    rows: list[str]
+
+
+@dataclass
+class LocStubGrandSummary(Loc):
+    rows: list[str]
+
+
+@dataclass
+class LocFootnotes(Loc):
+    groups: Literal["footnotes"] = "footnotes"
+
+
+@dataclass
+class LocSourceNotes(Loc):
+    # This dataclass in R has a `groups` field, which is a literal value.
+    # In python, we can use an isinstance check to determine we're seeing an
+    # instance of this class
+    groups: Literal["source_notes"] = "source_notes"
+
+
+def tab_style(data: GTData, style: list[CellStyle] | CellStyle, locations: Loc):
+    """Add custom style to one or more cells
+
+    Parameters
+    ----------
+    style:
+        A style specification.
+    location:
+        A location on the table.
+    """
+
+    raise NotImplementedError()

--- a/great_tables/_tbl_data.py
+++ b/great_tables/_tbl_data.py
@@ -189,14 +189,14 @@ def _(data: PlDataFrame, rows: List[int], columns: List[str]) -> PlDataFrame:
 
 
 @singledispatch
-def eval_select(data: DataFrameLike, expr: Any, strict: bool = True) -> list[str]:
+def eval_select(data: DataFrameLike, expr: Any, strict: bool = True) -> List[str]:
     """Return a list of column names selected by expr."""
 
     raise NotImplementedError(f"Unsupported type: {type(expr)}")
 
 
 @eval_select.register
-def _(data: PdDataFrame, expr: Union[list[str], Callable[[str], bool]]) -> list[str]:
+def _(data: PdDataFrame, expr: Union[List[str], Callable[[str], bool]]) -> List[str]:
     if isinstance(expr, list):
         # TODO: should prohibit duplicate names in expr?
         return [col for col in expr if col in data.columns]
@@ -209,7 +209,7 @@ def _(data: PdDataFrame, expr: Union[list[str], Callable[[str], bool]]) -> list[
 
 
 @eval_select.register
-def _(data: PlDataFrame, expr: Union[list[str], _selector_proxy_], strict=True) -> list[str]:
+def _(data: PlDataFrame, expr: Union[List[str], _selector_proxy_], strict=True) -> List[str]:
     # TODO: how to annotate type of a polars selector?
     # Seems to be polars.selectors._selector_proxy_.
     from polars import Expr

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -23,7 +23,6 @@ from great_tables._locale import LocaleAPI
 from great_tables._options import OptionsAPI
 from great_tables._row_groups import RowGroupsAPI
 from great_tables._source_notes import SourceNotesAPI
-from great_tables._spanners import SpannersAPI
 from great_tables._stub import reorder_stub_df
 from great_tables._stubhead import StubheadAPI
 from great_tables._styles import StylesAPI
@@ -57,7 +56,6 @@ class GT(
     TblDataAPI,
     BoxheadAPI,
     RowGroupsAPI,
-    SpannersAPI,
     HeadingAPI,
     StubheadAPI,
     SourceNotesAPI,

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -25,7 +25,6 @@ from great_tables._row_groups import RowGroupsAPI
 from great_tables._source_notes import SourceNotesAPI
 from great_tables._stub import reorder_stub_df
 from great_tables._stubhead import StubheadAPI
-from great_tables._styles import StylesAPI
 
 
 # from ._helpers import random_id
@@ -60,7 +59,6 @@ class GT(
     StubheadAPI,
     SourceNotesAPI,
     FootnotesAPI,
-    StylesAPI,
     LocaleAPI,
     FormatsAPI,
     OptionsAPI,

--- a/great_tables/gt.py
+++ b/great_tables/gt.py
@@ -23,6 +23,7 @@ from great_tables._locale import LocaleAPI
 from great_tables._options import OptionsAPI
 from great_tables._row_groups import RowGroupsAPI
 from great_tables._source_notes import SourceNotesAPI
+from great_tables._spanners import tab_spanner
 from great_tables._stub import reorder_stub_df
 from great_tables._stubhead import StubheadAPI
 
@@ -91,6 +92,7 @@ class GT(
     fmt_percent = fmt_percent
     fmt_integer = fmt_integer
     fmt_scientific = fmt_scientific
+    tab_spanner = tab_spanner
 
     # -----
 

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -1,0 +1,28 @@
+import pytest
+
+from great_tables._locations import LocColumnSpanners, resolve
+from great_tables._gt_data import Spanners, SpannerInfo
+
+
+def test_resolve_column_spanners_simple():
+    # note that this essentially a no-op
+    ids = ["a", "b", "c"]
+
+    spanners = Spanners([SpannerInfo(spanner_id=id) for id in ids])
+    loc = LocColumnSpanners(ids=["a", "c"])
+
+    new_loc = resolve(loc, spanners)
+
+    assert new_loc == loc
+    assert new_loc.ids == ["a", "c"]
+
+
+def test_resolve_column_spanners_error_missing():
+    # note that this essentially a no-op
+    ids = ["a", "b", "c"]
+
+    spanners = Spanners([SpannerInfo(spanner_id=id) for id in ids])
+    loc = LocColumnSpanners(ids=["a", "d"])
+
+    with pytest.raises(ValueError):
+        resolve(loc, spanners)

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -8,7 +8,7 @@ def test_resolve_column_spanners_simple():
     # note that this essentially a no-op
     ids = ["a", "b", "c"]
 
-    spanners = Spanners([SpannerInfo(spanner_id=id) for id in ids])
+    spanners = Spanners.from_ids(ids)
     loc = LocColumnSpanners(ids=["a", "c"])
 
     new_loc = resolve(loc, spanners)
@@ -21,7 +21,7 @@ def test_resolve_column_spanners_error_missing():
     # note that this essentially a no-op
     ids = ["a", "b", "c"]
 
-    spanners = Spanners([SpannerInfo(spanner_id=id) for id in ids])
+    spanners = Spanners.from_ids(ids)
     loc = LocColumnSpanners(ids=["a", "d"])
 
     with pytest.raises(ValueError):

--- a/tests/test_spanners.py
+++ b/tests/test_spanners.py
@@ -1,32 +1,57 @@
+import pytest
+
 from great_tables._spanners import spanners_print_matrix, empty_spanner_matrix
 from great_tables._gt_data import Spanners, SpannerInfo, Boxhead, ColInfo
 
 
-# TODO: test arguments
-
-
-def test_spanners_print_matrix():
-    spanners = Spanners(
+@pytest.fixture
+def spanners():
+    return Spanners(
         [
             SpannerInfo(spanner_id="a", spanner_level=0, vars=["col1"], built="A"),
             SpannerInfo(spanner_id="b", spanner_level=1, vars=["col2"], built="B"),
         ]
     )
 
-    boxhead = Boxhead(
+
+@pytest.fixture
+def boxhead():
+    return Boxhead(
         [
             ColInfo(var="col1"),
             ColInfo(var="col2"),
             ColInfo(var="col3"),
+            ColInfo(var="col4", visible=False),
         ]
     )
 
+
+def test_spanners_print_matrix(spanners, boxhead):
     mat, vars = spanners_print_matrix(spanners, boxhead)
     assert vars == ["col1", "col2", "col3"]
     assert mat == [
         {"col1": None, "col2": "B", "col3": None},
         {"col1": "A", "col2": None, "col3": None},
         {"col1": "col1", "col2": "col2", "col3": "col3"},
+    ]
+
+
+def test_spanners_print_matrix_arg_omit_columns_row(spanners, boxhead):
+    mat, vars = spanners_print_matrix(spanners, boxhead, omit_columns_row=True)
+    assert vars == ["col1", "col2", "col3"]
+    assert mat == [
+        {"col1": None, "col2": "B", "col3": None},
+        {"col1": "A", "col2": None, "col3": None},
+    ]
+
+
+def test_spanners_print_matrix_arg_include_hidden(spanners, boxhead):
+    mat, vars = spanners_print_matrix(spanners, boxhead, include_hidden=True)
+    assert vars == ["col1", "col2", "col3", "col4"]
+    assert mat == [
+        {"col1": None, "col2": "B", "col3": None, "col4": None},
+        {"col1": "A", "col2": None, "col3": None, "col4": None},
+        {"col1": "col1", "col2": "col2", "col3": "col3", "col4": "col4"},
     ]
 
 
@@ -38,7 +63,7 @@ def test_empty_spanner_matrix():
 
 
 def test_empty_spanner_matrix_arg_omit_columns_row():
-    mat, vars = empty_spanner_matrix(["a", "b"], omit_columns_row=False)
+    mat, vars = empty_spanner_matrix(["a", "b"], omit_columns_row=True)
 
     assert vars == ["a", "b"]
     assert mat == []

--- a/tests/test_spanners.py
+++ b/tests/test_spanners.py
@@ -1,7 +1,7 @@
 import pytest
 
 from great_tables._spanners import spanners_print_matrix, empty_spanner_matrix
-from great_tables._gt_data import Spanners, SpannerInfo, Boxhead, ColInfo
+from great_tables._gt_data import Spanners, SpannerInfo, Boxhead, ColInfo, ColInfoTypeEnum
 
 
 @pytest.fixture
@@ -21,7 +21,7 @@ def boxhead():
             ColInfo(var="col1"),
             ColInfo(var="col2"),
             ColInfo(var="col3"),
-            ColInfo(var="col4", visible=False),
+            ColInfo(var="col4", type=ColInfoTypeEnum.hidden),
         ]
     )
 

--- a/tests/test_spanners.py
+++ b/tests/test_spanners.py
@@ -1,0 +1,44 @@
+from great_tables._spanners import spanners_print_matrix, empty_spanner_matrix
+from great_tables._gt_data import Spanners, SpannerInfo, Boxhead, ColInfo
+
+
+# TODO: test arguments
+
+
+def test_spanners_print_matrix():
+    spanners = Spanners(
+        [
+            SpannerInfo(spanner_id="a", spanner_level=0, vars=["col1"], built="A"),
+            SpannerInfo(spanner_id="b", spanner_level=1, vars=["col2"], built="B"),
+        ]
+    )
+
+    boxhead = Boxhead(
+        [
+            ColInfo(var="col1"),
+            ColInfo(var="col2"),
+            ColInfo(var="col3"),
+        ]
+    )
+
+    mat, vars = spanners_print_matrix(spanners, boxhead)
+    assert vars == ["col1", "col2", "col3"]
+    assert mat == [
+        {"col1": None, "col2": "B", "col3": None},
+        {"col1": "A", "col2": None, "col3": None},
+        {"col1": "col1", "col2": "col2", "col3": "col3"},
+    ]
+
+
+def test_empty_spanner_matrix():
+    mat, vars = empty_spanner_matrix(["a", "b"], omit_columns_row=False)
+
+    assert vars == ["a", "b"]
+    assert mat == [{"a": "a", "b": "b"}]
+
+
+def test_empty_spanner_matrix_arg_omit_columns_row():
+    mat, vars = empty_spanner_matrix(["a", "b"], omit_columns_row=False)
+
+    assert vars == ["a", "b"]
+    assert mat == []


### PR DESCRIPTION
This PR fleshes out the Spanner class, to prepare for using it in rendering!

Main things added:

* Spanner class is not a Sequence of SpannerInfo entries
* Basic `spanner_print_matrix()` and `empty_spanner_matrix()`
  - Note that currently the matrix is just a list of dictionaries 😅 (but I wonder if this will work out okay? It seems like the renderers aren't using a lot of matrix stuff fingers crossed)
* dataclasses for cell styling (`Cell*`) and location selection (`_locate.Loc*`)
* generic `_locate.resolve()` function
  - Simple implementation for `resolve(LocSpannerColumns, ...)`